### PR TITLE
Make numbered list regex more strict

### DIFF
--- a/markdown/src/main/java/it/niedermann/android/markdown/MarkdownUtil.java
+++ b/markdown/src/main/java/it/niedermann/android/markdown/MarkdownUtil.java
@@ -45,8 +45,8 @@ public class MarkdownUtil {
     private static final HtmlRenderer RENDERER = HtmlRenderer.builder().softbreak("<br>").build();
 
     private static final Pattern PATTERN_CODE_FENCE = Pattern.compile("^(`{3,})");
-    private static final Pattern PATTERN_ORDERED_LIST_ITEM = Pattern.compile("^(\\d+).\\s.+$");
-    private static final Pattern PATTERN_ORDERED_LIST_ITEM_EMPTY = Pattern.compile("^(\\d+).\\s$");
+    private static final Pattern PATTERN_ORDERED_LIST_ITEM = Pattern.compile("^(\\d+)\\.\\s.+$");
+    private static final Pattern PATTERN_ORDERED_LIST_ITEM_EMPTY = Pattern.compile("^(\\d+)\\.\\s$");
     private static final Pattern PATTERN_MARKDOWN_LINK = Pattern.compile("\\[(.+)?]\\(([^ ]+?)?( \"(.+)\")?\\)");
 
     private static final String PATTERN_QUOTE_BOLD_PUNCTUATION = Pattern.quote("**");

--- a/markdown/src/test/java/it/niedermann/android/markdown/MarkdownUtilTest.kt
+++ b/markdown/src/test/java/it/niedermann/android/markdown/MarkdownUtilTest.kt
@@ -600,6 +600,12 @@ class MarkdownUtilTest : TestCase() {
         assertFalse(MarkdownUtil.getOrderedListNumber("11. ").isPresent)
         assertFalse(MarkdownUtil.getOrderedListNumber("-1. Test").isPresent)
         assertFalse(MarkdownUtil.getOrderedListNumber(" 1. Test").isPresent)
+        assertFalse(MarkdownUtil.getOrderedListNumber("123 Test").isPresent)
+        assertFalse(MarkdownUtil.getOrderedListNumber("123a Test").isPresent)
+        assertFalse(MarkdownUtil.getOrderedListNumber("123").isPresent)
+        assertFalse(MarkdownUtil.getOrderedListNumber("123a").isPresent)
+        assertFalse(MarkdownUtil.getOrderedListNumber("123 ").isPresent)
+        assertFalse(MarkdownUtil.getOrderedListNumber("123a ").isPresent)
     }
 
     @Test


### PR DESCRIPTION
The regexps used for identifying numbered lists were not strict enough, causing non-list lines to be identified as lists.

More information is on https://github.com/nextcloud/notes-android/issues/1848 - this PR fixes the described bug.