### PR TITLE
Split markdown into blocks so that checkboxes are singled out

### DIFF
--- a/markdown/src/main/java/it/niedermann/android/markdown/MarkdownUtil.java
+++ b/markdown/src/main/java/it/niedermann/android/markdown/MarkdownUtil.java
@@ -73,6 +73,7 @@ public class MarkdownUtil {
 
         ArrayList<RemoteViewElement> remoteViews = new ArrayList<>();
         StringBuilder currentLineBlock = new StringBuilder();
+        int startLine = 0;
 
         final String[] lines = content.split("\n");
         boolean isInFencedCodeBlock = false;
@@ -96,8 +97,14 @@ public class MarkdownUtil {
             }
             if (!isInFencedCodeBlock) {
                 if (isCheckboxLine(lines[i])) {
-                    remoteViews.add(new RemoteViewElement(RemoteViewElement.TYPE_TEXT, currentLineBlock.toString()));
+                    // if the first line is a checkbox, this will be an empty markdown block. It will also end in line -1.
+                    var endline = i-1;
+                    if(endline<0) {
+                        endline = 0;
+                    }
+                    remoteViews.add(new RemoteViewElement(RemoteViewElement.TYPE_TEXT, currentLineBlock.toString(), startLine, endline));
                     currentLineBlock = new StringBuilder();
+                    startLine = i+1;
 
                     boolean isChecked = false;
                     for (EListType listType : EListType.values()) {
@@ -106,9 +113,9 @@ public class MarkdownUtil {
                         }
                     }
                     if(isChecked) {
-                        remoteViews.add(new RemoteViewElement(RemoteViewElement.TYPE_CHECKBOX_CHECKED, lines[i]));
+                        remoteViews.add(new RemoteViewElement(RemoteViewElement.TYPE_CHECKBOX_CHECKED, lines[i], i, i));
                     } else {
-                        remoteViews.add(new RemoteViewElement(RemoteViewElement.TYPE_CHECKBOX_UNCHECKED, lines[i]));
+                        remoteViews.add(new RemoteViewElement(RemoteViewElement.TYPE_CHECKBOX_UNCHECKED, lines[i], i, i));
                     }
                     continue;
                 }

--- a/markdown/src/main/java/it/niedermann/android/markdown/remoteviews/RemoteViewElement.kt
+++ b/markdown/src/main/java/it/niedermann/android/markdown/remoteviews/RemoteViewElement.kt
@@ -4,7 +4,9 @@ import java.util.ArrayList
 
 class RemoteViewElement(
     val type: Int,
-    val currentLineBlock: String
+    val currentLineBlock: String,
+    val blockStartsInLine: Int,
+    val blockEndsInLine: Int
 ) {
 
     companion object {
@@ -28,6 +30,7 @@ class RemoteViewElement(
 
         elements.append("Content:").append("\n")
         elements.append(currentLineBlock).append("\n")
+        elements.append("Started from $blockStartsInLine to $blockEndsInLine").append("\n")
         return elements.toString()
     }
 }

--- a/markdown/src/main/java/it/niedermann/android/markdown/remoteviews/RemoteViewElement.kt
+++ b/markdown/src/main/java/it/niedermann/android/markdown/remoteviews/RemoteViewElement.kt
@@ -1,0 +1,33 @@
+package it.niedermann.android.markdown.remoteviews
+
+import java.util.ArrayList
+
+class RemoteViewElement(
+    val type: Int,
+    val currentLineBlock: String
+) {
+
+    companion object {
+        const val TYPE_TEXT = 0
+        const val TYPE_CHECKBOX_CHECKED = 1
+        const val TYPE_CHECKBOX_UNCHECKED = 2
+    }
+
+    override fun toString(): String {
+        var elements = StringBuilder()
+
+        if(type == TYPE_TEXT) {
+            elements.append("TYPE_TEXT").append("\n")
+        }
+        if(type == TYPE_CHECKBOX_CHECKED) {
+            elements.append("TYPE_CHECKBOX_CHECKED").append("\n")
+        }
+        if(type == TYPE_CHECKBOX_UNCHECKED) {
+            elements.append("TYPE_CHECKBOX_UNCHECKED").append("\n")
+        }
+
+        elements.append("Content:").append("\n")
+        elements.append(currentLineBlock).append("\n")
+        return elements.toString()
+    }
+}


### PR DESCRIPTION
This will seperate the markdown into different RemoteViewElements.

Each RemoteViewElement has a type and a text. The text corresponds to the raw, unrendered markdown, and the type will allow the result to be used more precisely.

I did this, so that i could implement checkboxes:

![image](https://github.com/nextcloud/notes-android/assets/25279821/b40442be-f1b4-4e29-af2f-59edc5a9e531)

I develop this library-extension in tandem with the actual widget. So while this is not really a draft, i would not merge this yet until i got the actual feature to be reviewed on the app-side.

See: https://github.com/nextcloud/notes-android/pull/1912