### PR TITLE
fix(markdown): ToggleCheckboxCa.java crash

### DIFF
--- a/markdown/src/main/java/it/niedermann/android/markdown/controller/applier/ToggleCheckboxCa.java
+++ b/markdown/src/main/java/it/niedermann/android/markdown/controller/applier/ToggleCheckboxCa.java
@@ -47,10 +47,10 @@ public class ToggleCheckboxCa implements CommandApplier {
             newSelection = selectionEnd + previousLineListType.checkboxUncheckedWithTrailingSpace.length();
         } else {
             if (startOfLine + listType.checkboxUncheckedWithTrailingSpace.length() > endOfLine) {
-                content.replace(startOfLine, listType.checkboxUnchecked.length(), "");
+                content.replace(startOfLine, startOfLine + listType.checkboxUnchecked.length(), "");
                 newSelection = selectionEnd - listType.checkboxUnchecked.length();
             } else {
-                content.replace(startOfLine, listType.checkboxUncheckedWithTrailingSpace.length(), "");
+                content.replace(startOfLine, startOfLine + listType.checkboxUncheckedWithTrailingSpace.length(), "");
                 newSelection = selectionEnd - listType.checkboxUncheckedWithTrailingSpace.length();
             }
         }


### PR DESCRIPTION
I was experiencing a crash in nextcloud notes when togging a checkbox off again. Every time an error report similar to the following would occur:

```
App Version: 4.3.1
App Version Code: 40030192
App Flavor: play

Files App Version Code: 30290290 (PROD)

---

OS Version: 5.10.198-android13-4-00050-g12f3388846c3-ab11920634(12231197)
OS API Level: 34
Device: lynx
Manufacturer: Google
Model (and Product): Pixel 7a (lynx)

---

java.lang.IndexOutOfBoundsException: replace (21 ... 6) has end before start
	at android.text.SpannableStringBuilder.checkRange(SpannableStringBuilder.java:1319)
	at android.text.SpannableStringBuilder.replace(SpannableStringBuilder.java:514)
	at android.text.SpannableStringBuilder.replace(SpannableStringBuilder.java:508)
	at android.text.SpannableStringBuilder.replace(SpannableStringBuilder.java:38)
	at it.niedermann.android.markdown.controller.applier.ToggleCheckboxCa.applyCommand(ToggleCheckboxCa.java:53)
	at it.niedermann.android.markdown.controller.Command.lambda$applyCommand$0(Command.java:71)
	at it.niedermann.android.markdown.controller.Command$$ExternalSyntheticLambda0.apply(D8$$SyntheticClass:0)
	at java.util.Optional.map(Optional.java:260)
	at it.niedermann.android.markdown.controller.Command.applyCommand(Command.java:71)
	at it.niedermann.android.markdown.markwon.MarkwonMarkdownEditor.executeCommand(MarkwonMarkdownEditor.java:314)
	at it.niedermann.android.markdown.markwon.format.AbstractFormattingCallback.onActionItemClicked(AbstractFormattingCallback.java:91)
	at android.widget.Editor$TextActionModeCallback.onActionItemClicked(Editor.java:4758)
	at com.android.internal.policy.DecorView$ActionModeCallback2Wrapper.onActionItemClicked(DecorView.java:2724)
	at com.android.internal.view.FloatingActionMode$3.onMenuItemSelected(FloatingActionMode.java:97)
	at com.android.internal.view.menu.MenuBuilder.dispatchMenuItemSelected(MenuBuilder.java:788)
	at com.android.internal.view.menu.MenuItemImpl.invoke(MenuItemImpl.java:152)
	at com.android.internal.view.menu.MenuBuilder.performItemAction(MenuBuilder.java:935)
	at com.android.internal.view.menu.MenuBuilder.performItemAction(MenuBuilder.java:925)
	at com.android.internal.view.FloatingActionMode.lambda$setFloatingToolbar$0(FloatingActionMode.java:122)
	at com.android.internal.view.FloatingActionMode.$r8$lambda$Y9Hq7gobR_VYnOvJY4KEpwtp1Qg(Unknown Source:0)
	at com.android.internal.view.FloatingActionMode$$ExternalSyntheticLambda0.onMenuItemClick(D8$$SyntheticClass:0)
	at com.android.internal.widget.floatingtoolbar.LocalFloatingToolbarPopup$2.onClick(LocalFloatingToolbarPopup.java:177)
	at android.view.View.performClick(View.java:7931)
	at android.view.View.performClickInternal(View.java:7908)
	at android.view.View.-$$Nest$mperformClickInternal(Unknown Source:0)
	at android.view.View$PerformClick.run(View.java:30990)
	at android.os.Handler.handleCallback(Handler.java:959)
	at android.os.Handler.dispatchMessage(Handler.java:100)
	at android.os.Looper.loopOnce(Looper.java:232)
	at android.os.Looper.loop(Looper.java:317)
	at android.app.ActivityThread.main(ActivityThread.java:8592)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:580)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:878)
```

This was pretty easy to trackdown to nextcloud-commons :markdown, it appears the original code was expecting Editable.replace to have arguments of start position and length, but instead Editable.replace expects start and end position. 